### PR TITLE
leverage devDeps and add 50k guid test

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/Frederick-S/is-guid/issues"
   },
   "homepage": "https://github.com/Frederick-S/is-guid#readme",
-  "dependencies": {
+  "devDependencies": {
+    "aguid": "^1.0.4",
     "codecov.io": "^0.1.6",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4"

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var isGuid = require('./index');
+var aguid = require('aguid');
 
 describe('Test string object type', function () {
     it('This is not a string', function () {
@@ -18,5 +19,13 @@ describe('Test valid guid string', function () {
         assert.equal(true, isGuid('d3aa88e2-c754-41e0-8ba6-4198a34aa0a2'));
         assert.equal(true, isGuid('{d3aa88e2-c754-41e0-8ba6-4198a34aa0a2}'));
         assert.equal(true, isGuid('{DF8B6CD9-A928-4FA0-B106-DE183AC05DAA}'));
+    });
+});
+
+describe('Test 50,000 guid strings', function () {
+    it('validated 50,000 guids', function () {
+        for (var i = 0; i < 50000; i++) {
+            assert.equal(true, isGuid(aguid()));
+        }
     });
 });


### PR DESCRIPTION
Thanks for creating this package!

This pull request switches the development/testing dependencies to use `devDependencies` to avoid unnecessary install when this package is depended upon. It also includes a "fuzz" test of 50,000 random guids.